### PR TITLE
Correct incorrect ProximityOrder overload in SpatialDatabase.cs

### DIFF
--- a/Assets/Scripts/Utilities/SpatialDatabase/SpatialDatabase.cs
+++ b/Assets/Scripts/Utilities/SpatialDatabase/SpatialDatabase.cs
@@ -300,7 +300,7 @@ public struct SpatialDatabase : IComponentData
         UnsafeList<SpatialDatabaseElement> elements =
             new UnsafeList<SpatialDatabaseElement>((SpatialDatabaseElement*)elementsBuffer.GetUnsafeReadOnlyPtr(),
                 elementsBuffer.Length);
-        QueryAABB(in spatialDatabase, in cells, in elements, center, halfExtents, ref collector);
+        QueryAABBCellProximityOrder(in spatialDatabase, in cells, in elements, center, halfExtents, ref collector);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Hello!

Seems like we want to use ProximityOrder for the proximity function. Love the sample, great work!